### PR TITLE
Add 'make' and 'build-base' intsallations to ethereum Dockerfile

### DIFF
--- a/integration_tests/ethereum/Dockerfile
+++ b/integration_tests/ethereum/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14-alpine3.13
 
 RUN apk update
-RUN apk add --no-cache git python3
+RUN apk add --no-cache git python3 make build-base
 
 COPY package.json package.json
 COPY yarn.lock yarn.lock


### PR DESCRIPTION
## Description

When running docker build on the new M1 platform, builds were failing
because make and gcc were not installed in the image. build-base is an
alpine package that installs gcc.