### PR TITLE
Use self hosted test runner

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -64,7 +64,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -108,7 +108,7 @@ jobs:
 
   integration-tests:
     environment: CI
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     needs: [ sommelier-build, hardhat-build ]
     strategy:
       fail-fast: false


### PR DESCRIPTION
Running integration tests on self hosted test runner due to higher resource requirements.

Uses gcloud hosted test runner `sommelier-github-actions-testrunner-1`

Machine is setup with type `n2d-standard-4`, 4 CPU, 16GB RAM

