### PR TITLE
DNM: Testing to see if the log matching is off

### DIFF
--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -680,7 +680,7 @@ msg_batch_size = 5
 	// TODO(mvid) Determine if there is a way to check the health or status of
 	// the gorc orchestrator processes. For now, we search the logs to determine
 	// when each orchestrator resource has synced all batches
-	match := "orchestrator::main_loop: No unsigned batches! Everything good!"
+	match := "No unsigned batches! Everything good!"
 	for _, resource := range s.orchResources {
 		resource := resource
 		s.T().Logf("waiting for orchestrator to be healthy: %s", resource.Container.ID)


### PR DESCRIPTION
Making a PR to get CI to run to see if changing the log string fixes the orchestrator not being seen as healthy. I started getting this issue in my local runs and this made it work, so figure it's worth a shot.
