### PR TITLE
Update proto go packages to v3

### DIFF
--- a/proto/allocation/v1/allocation.proto
+++ b/proto/allocation/v1/allocation.proto
@@ -3,7 +3,7 @@ package allocation.v1;
 
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/peggyjv/sommelier/x/allocation/types";
+option go_package = "github.com/peggyjv/sommelier/v3/x/allocation/types";
 
 // AllocationPrecommit defines an array of hashed data to be used for the precommit phase
 // of allocation

--- a/proto/allocation/v1/genesis.proto
+++ b/proto/allocation/v1/genesis.proto
@@ -5,7 +5,7 @@ import "allocation/v1/tx.proto";
 import "allocation/v1/allocation.proto";
 import "gogoproto/gogo.proto";
 
-option go_package = "github.com/peggyjv/sommelier/x/allocation/types";
+option go_package = "github.com/peggyjv/sommelier/v3/x/allocation/types";
 
 
 // GenesisState - all allocation state that must be provided at genesis

--- a/proto/allocation/v1/query.proto
+++ b/proto/allocation/v1/query.proto
@@ -8,7 +8,7 @@ import "allocation/v1/allocation.proto";
 import "cosmos_proto/cosmos.proto";
 import "cosmos/base/query/v1beta1/pagination.proto";
 
-option go_package = "github.com/peggyjv/sommelier/x/allocation/types";
+option go_package = "github.com/peggyjv/sommelier/v3/x/allocation/types";
 
 // Query defines the gRPC querier service for the allocation module.
 service Query {

--- a/proto/allocation/v1/tx.proto
+++ b/proto/allocation/v1/tx.proto
@@ -5,7 +5,7 @@ import "cosmos_proto/cosmos.proto";
 import "google/protobuf/any.proto";
 import "allocation/v1/allocation.proto";
 
-option go_package = "github.com/peggyjv/sommelier/x/allocation/types";
+option go_package = "github.com/peggyjv/sommelier/v3/x/allocation/types";
 
 // MsgService defines the msgs that the oracle module handles.
 service Msg {


### PR DESCRIPTION
The `go_package` options in the `allocation` proto files did not have their paths updated to account for v3.
