### PR TITLE
Point orchestrator at main rather than latest

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,7 +11,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  ORCHESTRATOR_IMAGE_NAME: ghcr.io/peggyjv/gravity-bridge-orchestrator:latest
+  ORCHESTRATOR_IMAGE_NAME: ghcr.io/peggyjv/gravity-bridge-orchestrator:main
 
 jobs:
   sommelier-build:

--- a/Makefile
+++ b/Makefile
@@ -351,7 +351,7 @@ tools-clean:
 # Integration tests #
 #####################
 
-ORCHESTRATOR_IMAGE := "ghcr.io/peggyjv/gravity-bridge-orchestrator:latest"
+ORCHESTRATOR_IMAGE := "ghcr.io/peggyjv/gravity-bridge-orchestrator:main"
 
 e2e_build_images: e2e_clean_slate
 	@docker pull $(ORCHESTRATOR_IMAGE)


### PR DESCRIPTION
Until we cut a release, point the orchestrator image at gravity-bridge main.