### PR TITLE
Remove cellarfees module account balance check

### DIFF
--- a/x/cellarfees/keeper/genesis.go
+++ b/x/cellarfees/keeper/genesis.go
@@ -17,14 +17,7 @@ func InitGenesis(ctx sdk.Context, k Keeper, gs types.GenesisState) {
 		panic(fmt.Sprintf("%s module account has not been set", types.ModuleName))
 	}
 
-	// TODO(bolten): I added this check since other cosmos-sdk modules were doing this,
-	// but it seems to me that SetModuleAccount is getting called when GetModuleAccount
-	// has to create a new module account anyway, which will happen by proxy when we call
-	// GetFeesAccount, so not sure how necessary this is
-	balances := k.bankKeeper.GetAllBalances(ctx, feesAccount.GetAddress())
-	if balances.IsZero() {
-		k.accountKeeper.SetModuleAccount(ctx, feesAccount)
-	}
+	k.accountKeeper.SetModuleAccount(ctx, feesAccount)
 }
 
 // ExportGenesis returns the module's exported genesis.


### PR DESCRIPTION
There is money in the banana stand already, so we have to remove the balance zero check since some funds were sent to the module account using a live test cellar.

If there is already coins in that account, will it work correctly just by calling `SetModuleAccount` or could something funky happen?