### PR TITLE
Add -a flag for `gorc sign-delegate-keys`

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ sommelier tx gravity set-delegate-keys \
     $(sommelier keys show validator --bech val -a) \ # validator address
     $(gorc --config $HOME/gorc/config.toml keys cosmos show orchestrator) \ # orchestrator address (this must be run manually and address extracted)
     $(gorc --config $HOME/gorc/config.toml keys eth show signer) \ # eth signer address
-    $(gorc --config $HOME/gorc/config.toml sign-delegate-keys signer $(sommelier keys show validator --bech val -a)) \ 
+    $(gorc --config $HOME/gorc/config.toml sign-delegate-keys -a signer -a $(sommelier keys show validator --bech val -a)) \ 
     --chain-id sommelier-3 \ 
     --from validator \ 
     -y


### PR DESCRIPTION

<!-- 
☺ Thanks for opening a PR! We really appreciate the contribution! ☺ 
    If your PR closes an issue, indicate the issue number below
-->

Closes: #142

`gorc sign-delegate-keys` requires the `-a` flag before arguments.

## Description

Update README to tell users to pass the right flag to `gorc sign-delegate-keys`.