### PR TITLE
Fix module account overlap

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -747,6 +747,7 @@ func (app *SommelierApp) setupUpgradeHandlers() {
 		v4.CreateUpgradeHandler(
 			app.mm,
 			app.configurator,
+			app.AccountKeeper,
 			app.BankKeeper,
 		),
 	)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/miguelmota/go-ethereum-hdwallet v0.1.1
 	github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 // indirect
 	github.com/ory/dockertest/v3 v3.8.1
-	github.com/peggyjv/gravity-bridge/module/v2 v2.0.0-20220414233948-fb045a1867b7 // indirect
+	github.com/peggyjv/gravity-bridge/module/v2 v2.0.0-20220420162017-838c0d25e974 // indirect
 	github.com/rakyll/statik v0.1.7
 	github.com/regen-network/cosmos-proto v0.3.1
 	github.com/spf13/cast v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -803,6 +803,8 @@ github.com/pborman/uuid v0.0.0-20170112150404-1b00554d8222/go.mod h1:VyrYX9gd7ir
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/peggyjv/gravity-bridge/module/v2 v2.0.0-20220414233948-fb045a1867b7 h1:VtMZq6qdukLwdx5K+OG36WaMu19RJBBFzLgPlfCqyi8=
 github.com/peggyjv/gravity-bridge/module/v2 v2.0.0-20220414233948-fb045a1867b7/go.mod h1:XUHyaIYlqo2TgCSY0R4N/geZot6Vks/EZmhJ7Jz4wvQ=
+github.com/peggyjv/gravity-bridge/module/v2 v2.0.0-20220420162017-838c0d25e974 h1:6rGtwj8oqkuGLQOuzbYgaNPumr5Trl3032jtJHhaUS8=
+github.com/peggyjv/gravity-bridge/module/v2 v2.0.0-20220420162017-838c0d25e974/go.mod h1:XUHyaIYlqo2TgCSY0R4N/geZot6Vks/EZmhJ7Jz4wvQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=


### PR DESCRIPTION
A normal account was accidentally created with the `cellarfees` module account address. Since it can't be converted into a module account in its present state, the only alternatives are to remove the account or rename the module. This is a version of the upgrade that does the former, opening this PR for review to determine if that's what we should do, or if we should just rename the module. This upgrade plan appears to have worked in the testnet.
