### PR TITLE
Delete populated module account first

### DIFF
--- a/app/upgrades/v4/upgrades.go
+++ b/app/upgrades/v4/upgrades.go
@@ -35,11 +35,11 @@ func CreateUpgradeHandler(
 		// Overwrite the gravity module's version back to 1 so the migration will run to v2
 		fromVM[gravitytypes.ModuleName] = 1
 
-		ctx.Logger().Info("v4 upgrade: normalizing gravity denoms in bank balances")
-		normalizeGravityDenoms(ctx, bankKeeper)
-
 		ctx.Logger().Info("v4 upgrade: removing existing account with module address overlap")
 		removeModuleAccountOverlap(ctx, accountKeeper, bankKeeper)
+
+		ctx.Logger().Info("v4 upgrade: normalizing gravity denoms in bank balances")
+		normalizeGravityDenoms(ctx, bankKeeper)
 
 		ctx.Logger().Info("v4 upgrade: running migrations and exiting handler")
 		return mm.RunMigrations(ctx, configurator, fromVM)


### PR DESCRIPTION
The final commit that was merged to update the gravity version included a change that removed the "cellarfees" module account address as "allowed to receive" funds. This version of the node was running successfully in the testnet, but had not been through a full upgrade again. Removing it as a receivable account means we have to switch the order of operations in the upgrade to delete the module account overlap first, otherwise the denom fix will try to send coins back to the account and cause a panic.