### PR TITLE
Fix tendermint routing bug/releaser bug

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Build
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v1.9.2
           args: build --skip-validate   # skip validate skips initial sanity checks in order to be able to fully run
 
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          version: latest
+          version: v1.9.2
           args: release --rm-dist --release-notes=../release_notes.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/app.go
+++ b/app/app.go
@@ -660,6 +660,8 @@ func (app *SommelierApp) RegisterAPIRoutes(apiSvr *api.Server, apiConfig config.
 	authrest.RegisterTxRoutes(clientCtx, apiSvr.Router)
 	// Register new tx routes from grpc-gateway.
 	authtx.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
+	// Register new tendermint queries routes from grpc-gateway.
+	tmservice.RegisterGRPCGatewayRoutes(clientCtx, apiSvr.GRPCGatewayRouter)
 
 	// Register legacy and grpc-gateway routes for all modules.
 	ModuleBasics.RegisterRESTRoutes(clientCtx, apiSvr.Router)


### PR DESCRIPTION
Register GRPC gateway routes to tendermint so queries in the form of e.g. `/cosmos/base/tendermint/v1beta1/blocks/latest` will route correctly. Also pin to a version of the `goreleaser` that works with our build.