### PR TITLE
CI docker image platform bugfix

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -54,6 +54,7 @@ jobs:
           context: .
           file: Dockerfile
           push: true
+          platforms: linux/amd64, linux/arm64/v8
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           builder: ${{ steps.buildx.outputs.name }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -101,6 +101,7 @@ jobs:
           context: integration_tests/ethereum
           file: integration_tests/ethereum/Dockerfile
           push: true
+          platforms: linux/amd64, linux/arm64/v8
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           builder: ${{ steps.buildx.outputs.name }}


### PR DESCRIPTION
Explicitly sets build platforms for workflows to fix a bug that prevents pulling when using an M1 mac