### PR TITLE
Fix interval auction

### DIFF
--- a/integration_tests/setup_test.go
+++ b/integration_tests/setup_test.go
@@ -420,6 +420,7 @@ func (s *IntegrationTestSuite) initGenesis() {
 		RewardEmissionPeriod:       100,
 		InitialPriceDecreaseRate:   sdk.MustNewDecFromStr("0.05"),
 		PriceDecreaseBlockInterval: uint64(1000),
+		AuctionInterval:            50,
 	}
 	bz, err = cdc.MarshalJSON(&cellarfeesGenState)
 	s.Require().NoError(err)

--- a/x/cellarfees/keeper/hooks.go
+++ b/x/cellarfees/keeper/hooks.go
@@ -59,6 +59,7 @@ func (h Hooks) AfterSendToCosmosEvent(ctx sdk.Context, event gravitytypes.SendTo
 
 	counters := h.k.GetFeeAccrualCounters(ctx)
 	count := counters.IncrementCounter(denom)
+	h.k.SetFeeAccrualCounters(ctx, counters)
 
 	ctx.EventManager().EmitEvents(
 		sdk.Events{

--- a/x/cellarfees/types/params.go
+++ b/x/cellarfees/types/params.go
@@ -18,7 +18,7 @@ const (
 	// Blocks between each auction price decrease
 	DefaultPriceDecreaseBlockInterval uint64 = 10
 	// Blocks between each auction
-	DefaultAuctionInterval uint64 = 1000
+	DefaultAuctionInterval uint64 = 15000
 )
 
 // Parameter keys


### PR DESCRIPTION
* Set a low auction interval in the integration test genesis state
* Add back the part where the hooks record state into the counters (IncrementCounters does not modify the KV store)
* Set the default interval value to the one I saw Kristi mention
