### PR TITLE
fix: fix slice init length

### DIFF
--- a/integration_tests/chain.go
+++ b/integration_tests/chain.go
@@ -184,7 +184,7 @@ func (c *chain) createAndInitProposerWithMnemonic(mnemonic string) error {
 }
 
 func (c *chain) createAndInitOrchestrators(count int) error { //nolint:unused
-	mnemonics := make([]string, count)
+	mnemonics := make([]string, 0, count)
 	for i := 0; i < count; i++ {
 		mnemonic, err := createMnemonic()
 		if err != nil {


### PR DESCRIPTION
<!-- 
☺ Thanks for opening a PR! We really appreciate the contribution! ☺ 
    If your PR closes an issue, indicate the issue number below
-->

Closes: #XXX

<!-- 
Please add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

## Description

The purpose here should be to initialize a slice with a capacity of `count ` and a length of 0, and then append it later. Instead of initializing the length to `count ` from the beginning, the resulting slice will not meet expectations.

The online demo: https://go.dev/play/p/q1BcVCmvidW



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Optimized memory allocation for mnemonic initialization in the orchestration process. 
	- Maintained existing functionality without changes to public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->