### PR TITLE
security: Upgrade CometBFT to v0.37.18 and fix nil validator panic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cosmossdk.io/api v0.3.1
 	cosmossdk.io/errors v1.0.1
 	cosmossdk.io/math v1.4.0
-	github.com/cometbft/cometbft v0.37.15
+	github.com/cometbft/cometbft v0.37.18
 	github.com/cometbft/cometbft-db v0.11.0
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
 	github.com/cosmos/cosmos-sdk v0.47.15

--- a/go.sum
+++ b/go.sum
@@ -723,8 +723,8 @@ github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0 h1:jpVIwLcPoOeCR6o1tU+Xv7r5bMONNbHU7MuEHboiFuA=
 github.com/coinbase/rosetta-sdk-go/types v1.0.0/go.mod h1:eq7W2TMRH22GTW0N0beDnN931DW0/WOI1R2sdHNHG4c=
-github.com/cometbft/cometbft v0.37.15 h1:un+iXPh7naon5e7LQgKB2BYcrnAG0SGmUgDesyX7FII=
-github.com/cometbft/cometbft v0.37.15/go.mod h1:t/BvwfSJKt2HUHX01L6y1+uw+LOoxU6hFj447wOB5IA=
+github.com/cometbft/cometbft v0.37.18 h1:JIjGMHxPqnuoGcCn3gRnmFSCBP6bCIeJWWWILwiDwUk=
+github.com/cometbft/cometbft v0.37.18/go.mod h1:t/BvwfSJKt2HUHX01L6y1+uw+LOoxU6hFj447wOB5IA=
 github.com/cometbft/cometbft-db v0.11.0 h1:M3Lscmpogx5NTbb1EGyGDaFRdsoLWrUWimFEyf7jej8=
 github.com/cometbft/cometbft-db v0.11.0/go.mod h1:GDPJAC/iFHNjmZZPN8V8C1yr/eyityhi2W1hz2MGKSc=
 github.com/confio/ics23/go v0.9.0 h1:cWs+wdbS2KRPZezoaaj+qBleXgUk5WOQFMP3CQFGTr4=

--- a/x/axelarcork/keeper/keeper.go
+++ b/x/axelarcork/keeper/keeper.go
@@ -365,6 +365,14 @@ func (k Keeper) GetApprovedScheduledAxelarCorks(ctx sdk.Context, chainID uint64)
 	powers := []uint64{}
 	k.IterateScheduledAxelarCorksByBlockHeight(ctx, chainID, currentBlockHeight, func(val sdk.ValAddress, _ uint64, id []byte, addr common.Address, cork types.AxelarCork) (stop bool) {
 		validator := k.stakingKeeper.Validator(ctx, val)
+
+		// Skip if validator no longer exists (e.g., fully unbonded)
+		if validator == nil {
+			k.DeleteScheduledAxelarCork(ctx, chainID, currentBlockHeight, id, val, addr)
+			k.DecrementValidatorAxelarCorkCount(ctx, val)
+			return false
+		}
+
 		validatorPower := uint64(validator.GetConsensusPower(k.stakingKeeper.PowerReduction(ctx)))
 		found := false
 		for i, c := range corks {

--- a/x/cork/keeper/keeper.go
+++ b/x/cork/keeper/keeper.go
@@ -285,6 +285,14 @@ func (k Keeper) GetApprovedScheduledCorks(ctx sdk.Context) (approvedCorks []type
 	powers := []uint64{}
 	k.IterateScheduledCorksByBlockHeight(ctx, currentBlockHeight, func(val sdk.ValAddress, _ uint64, id []byte, addr common.Address, cork types.Cork) (stop bool) {
 		validator := k.stakingKeeper.Validator(ctx, val)
+
+		// Skip if validator no longer exists (e.g., fully unbonded)
+		if validator == nil {
+			k.DeleteScheduledCork(ctx, currentBlockHeight, id, val, addr)
+			k.DecrementValidatorCorkCount(ctx, val)
+			return false
+		}
+
 		validatorPower := uint64(validator.GetConsensusPower(k.stakingKeeper.PowerReduction(ctx)))
 		found := false
 		for i, c := range corks {


### PR DESCRIPTION
## Summary

- Upgrades CometBFT from v0.37.15 to v0.37.18 which contains security patches
- Fixes potential panic when processing scheduled corks for validators that no longer exist (e.g., fully unbonded validators)

## Changes

- **go.mod/go.sum**: Bump `github.com/cometbft/cometbft` v0.37.15 → v0.37.18
- **x/cork/keeper/keeper.go**: Add nil check for validator in `GetApprovedScheduledCorks`
- **x/axelarcork/keeper/keeper.go**: Add nil check for validator in `GetApprovedScheduledAxelarCorks`

## Test plan

- [x] `go build ./cmd/...` compiles successfully
- [x] `go test ./x/... ./app/... -short` passes

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of missing validators in scheduled transaction processing. The system now properly detects and manages cases where validators have been removed or unbonded by automatically cleaning up associated pending transactions and ensuring queue consistency and data integrity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->