### PR TITLE
cork: give the cork authority a working CLI for the cellar wind-down

### DIFF
--- a/app/upgrades/v10/upgrades.go
+++ b/app/upgrades/v10/upgrades.go
@@ -48,7 +48,7 @@ func CreateUpgradeHandler(
 				"v10 upgrade refuses to run: DefaultAuthorityValidators is empty. " +
 					"Populate app/upgrades/v10/constants.go with the production authority validator " +
 					"set before tagging the release, or the chain will enter safe mode on the next " +
-					"block (value-bearing modules frozen) because the authority set is empty.",
+					"block (value-bearing modules frozen) because the authority set is empty",
 			)
 		}
 

--- a/x/axelarcork/client/cli/tx.go
+++ b/x/axelarcork/client/cli/tx.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/version"
 	govtypesv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	types "github.com/peggyjv/sommelier/v10/x/axelarcork/types"
 	pubsubtypes "github.com/peggyjv/sommelier/v10/x/pubsub/types"
 	"github.com/spf13/cobra"
@@ -42,6 +43,61 @@ func GetTxCmd() *cobra.Command {
 // Commands //
 //////////////
 
+// buildScheduleAxelarCorkMsg assembles a MsgScheduleAxelarCorkRequest from CLI
+// input.
+//
+// The encoded call is taken as hex and DECODED to bytes. This previously did
+// []byte(args[3]), which handed the cellar the ASCII of the hex string: the
+// Sommelier transaction succeeds, the relayed call then reverts on the
+// destination chain, and nothing locally indicates why.
+//
+// deadline is a unix timestamp enforced by the destination proxy contract. It
+// was never set by this command before, so ValidateBasic rejected every
+// invocation with "deadline must be non-zero" -- schedule-axelar-cork has never
+// worked. It is now a required --deadline flag.
+//
+// Split out from the cobra command so the encoding rules are testable without a
+// client context.
+// FlagDeadline names the required deadline flag on schedule-axelar-cork.
+const FlagDeadline = "deadline"
+
+func buildScheduleAxelarCorkMsg(signer string, chainID uint64, contractAddr string, blockHeight, deadline uint64, encodedCall string) (*types.MsgScheduleAxelarCorkRequest, error) {
+	if !common.IsHexAddress(contractAddr) {
+		return nil, fmt.Errorf("target contract address %s is invalid", contractAddr)
+	}
+
+	callBz, err := hexutil.Decode(withHexPrefix(encodedCall))
+	if err != nil {
+		return nil, fmt.Errorf("contract call must be hex-encoded ABI bytes: %w", err)
+	}
+	if len(callBz) == 0 {
+		return nil, fmt.Errorf("contract call is empty; an empty body is never a valid cellar instruction")
+	}
+
+	msg := &types.MsgScheduleAxelarCorkRequest{
+		Cork: &types.AxelarCork{
+			EncodedContractCall:   callBz,
+			ChainId:               chainID,
+			TargetContractAddress: contractAddr,
+			Deadline:              deadline,
+		},
+		ChainId:     chainID,
+		BlockHeight: blockHeight,
+		Signer:      signer,
+	}
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+
+func withHexPrefix(s string) string {
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		return s
+	}
+	return "0x" + s
+}
+
 func CmdScheduleAxelarCork() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "schedule-axelar-cork [chain-id] [contract-address] [block-height] [contract-call]",
@@ -62,35 +118,32 @@ func CmdScheduleAxelarCork() *cobra.Command {
 			}
 
 			contractAddr := args[1]
-			if !common.IsHexAddress(contractAddr) {
-				return fmt.Errorf("contract address %s is invalid", contractAddr)
-			}
 
 			blockHeight, err := math.ParseUint(args[2])
 			if err != nil {
 				return err
 			}
 
-			contractCallBz := []byte(args[3]) // todo: how are contract calls submitted?
-
-			scheduleCorkMsg := types.MsgScheduleAxelarCorkRequest{
-				Cork: &types.AxelarCork{
-					EncodedContractCall:   contractCallBz,
-					ChainId:               chainID.Uint64(),
-					TargetContractAddress: contractAddr,
-				},
-				ChainId:     chainID.Uint64(),
-				BlockHeight: blockHeight.Uint64(),
-				Signer:      from.String(),
-			}
-			if err := scheduleCorkMsg.ValidateBasic(); err != nil {
+			deadline, err := cmd.Flags().GetUint64(FlagDeadline)
+			if err != nil {
 				return err
 			}
-			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), &scheduleCorkMsg)
+			if deadline == 0 {
+				return fmt.Errorf("--%s is required: unix timestamp before which the call must execute on the destination chain", FlagDeadline)
+			}
+
+			scheduleCorkMsg, err := buildScheduleAxelarCorkMsg(
+				from.String(), chainID.Uint64(), contractAddr, blockHeight.Uint64(), deadline, args[3])
+			if err != nil {
+				return err
+			}
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), scheduleCorkMsg)
 
 		},
 	}
 
+	cmd.Flags().Uint64(FlagDeadline, 0,
+		"unix timestamp before which the contract call must execute on the destination chain (required; enforced by the proxy contract)")
 	flags.AddTxFlagsToCmd(cmd)
 	return cmd
 }

--- a/x/axelarcork/client/cli/tx_test.go
+++ b/x/axelarcork/client/cli/tx_test.go
@@ -5,12 +5,20 @@ import (
 	"testing"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/peggyjv/sommelier/v10/app/params"
 	"github.com/peggyjv/sommelier/v10/x/axelarcork/types"
 
 	"github.com/cosmos/cosmos-sdk/testutil"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+// The SDK config defaults to the "cosmos" bech32 prefix; the app sets "somm" at
+// init. Without this, somm1... addresses fail ValidateBasic misleadingly.
+func TestMain(m *testing.M) {
+	params.SetAddressPrefixes()
+	os.Exit(m.Run())
+}
 
 func TestParseAddManagedCellarsProposal(t *testing.T) {
 	encodingConfig := moduletestutil.MakeTestEncodingConfig()
@@ -246,4 +254,66 @@ func TestParseCancelAxelarProxyContractUpgradeProposal(t *testing.T) {
 	require.Equal(t, "I have a hunch", proposal.Description)
 	require.Equal(t, uint64(42161), proposal.ChainId)
 	require.Equal(t, "10000usomm", proposal.Deposit)
+}
+
+// schedule-axelar-cork previously did []byte(args[3]) under a
+// "todo: how are contract calls submitted?" comment, which handed the cellar the
+// ASCII of the hex string rather than the ABI-encoded call. The transaction
+// succeeds on Sommelier and the call then reverts on the destination chain, with
+// nothing locally to indicate why -- a bad failure mode for a cellar wind-down.
+func TestBuildScheduleAxelarCorkMsg(t *testing.T) {
+	const (
+		cellar  = "0x123801a7D398351b8bE11C439e05C5B3259aeC9B"
+		signer  = "somm1lcsjy2d5s33h0sddd8lpuqvwyz5ruz7ju4aeqa"
+		chainID = uint64(42161)
+	)
+
+	t.Run("hex call is decoded to bytes", func(t *testing.T) {
+		msg, err := buildScheduleAxelarCorkMsg(signer, chainID, cellar, 1000, 1800000000, "0xdeadbeef")
+		require.NoError(t, err)
+		require.Equal(t, []byte{0xde, 0xad, 0xbe, 0xef}, msg.Cork.EncodedContractCall)
+		require.Equal(t, cellar, msg.Cork.TargetContractAddress)
+		require.Equal(t, chainID, msg.Cork.ChainId)
+		require.Equal(t, chainID, msg.ChainId)
+		require.Equal(t, uint64(1000), msg.BlockHeight)
+		require.Equal(t, signer, msg.Signer)
+	})
+
+	t.Run("0x prefix is optional", func(t *testing.T) {
+		msg, err := buildScheduleAxelarCorkMsg(signer, chainID, cellar, 1000, 1800000000, "deadbeef")
+		require.NoError(t, err)
+		require.Equal(t, []byte{0xde, 0xad, 0xbe, 0xef}, msg.Cork.EncodedContractCall)
+	})
+
+	t.Run("rejects a non-hex call", func(t *testing.T) {
+		_, err := buildScheduleAxelarCorkMsg(signer, chainID, cellar, 1000, 1800000000, "not-hex")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects an invalid cellar address", func(t *testing.T) {
+		_, err := buildScheduleAxelarCorkMsg(signer, chainID, "0xnothex", 1000, 1800000000, "0xdeadbeef")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects an empty call", func(t *testing.T) {
+		_, err := buildScheduleAxelarCorkMsg(signer, chainID, cellar, 1000, 1800000000, "0x")
+		require.Error(t, err)
+	})
+}
+
+// The deadline is what made this command unusable: it was never set, so
+// ValidateBasic rejected every invocation. Pin that it is required.
+func TestBuildScheduleAxelarCorkMsgRequiresDeadline(t *testing.T) {
+	_, err := buildScheduleAxelarCorkMsg(
+		"somm1lcsjy2d5s33h0sddd8lpuqvwyz5ruz7ju4aeqa", 42161,
+		"0x123801a7D398351b8bE11C439e05C5B3259aeC9B", 1000, 0, "0xdeadbeef")
+	require.ErrorContains(t, err, "deadline")
+}
+
+// The flag must actually be wired to the command, or the deadline silently
+// stays zero and every invocation fails again.
+func TestScheduleAxelarCorkCmdExposesDeadlineFlag(t *testing.T) {
+	cmd := CmdScheduleAxelarCork()
+	require.NotNil(t, cmd.Flags().Lookup(FlagDeadline),
+		"schedule-axelar-cork must expose --"+FlagDeadline)
 }

--- a/x/axelarcork/keeper/msg_server_authority_test.go
+++ b/x/axelarcork/keeper/msg_server_authority_test.go
@@ -132,6 +132,7 @@ func TestAllHandlersRejectNonAuthority(t *testing.T) {
 	}
 
 	for _, tc := range cases {
+		tc := tc // capture per iteration; the subtests below close over it
 		t.Run(tc.name, func(t *testing.T) {
 			k, ctx, contract := authorityFixture(t, testCorkAuthority)
 			err := tc.call(k, ctx, contract)

--- a/x/cork/client/cli/tx.go
+++ b/x/cork/client/cli/tx.go
@@ -3,14 +3,17 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/version"
 	govtypesv1beta1 "github.com/cosmos/cosmos-sdk/x/gov/types/v1beta1"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	types "github.com/peggyjv/sommelier/v10/x/cork/types/v2"
 	pubsubtypes "github.com/peggyjv/sommelier/v10/x/pubsub/types"
 	"github.com/spf13/cobra"
@@ -26,8 +29,98 @@ func GetTxCmd() *cobra.Command {
 		RunE:                       client.ValidateCmd,
 	}
 
-	// todo(mvid): figure out what is useful, implement
+	corkTxCmd.AddCommand(CmdScheduleCork())
+
 	return corkTxCmd
+}
+
+// buildScheduleCorkMsg assembles a MsgScheduleCorkRequest from CLI input.
+//
+// Split out from the cobra command so the encoding rules are testable without a
+// client context. The encoded call is the part worth guarding: the chain expects
+// raw ABI-encoded bytes, so the hex must be DECODED here. Handing the message
+// []byte(hexString) instead would pass the ASCII of the hex through to the
+// cellar, which reverts on Ethereum with nothing locally to explain why.
+func buildScheduleCorkMsg(signer, contractAddr string, blockHeight uint64, encodedCall string) (*types.MsgScheduleCorkRequest, error) {
+	if !common.IsHexAddress(contractAddr) {
+		return nil, fmt.Errorf("target contract address %s is invalid", contractAddr)
+	}
+
+	callBz, err := hexutil.Decode(withHexPrefix(encodedCall))
+	if err != nil {
+		return nil, fmt.Errorf("contract call must be hex-encoded ABI bytes: %w", err)
+	}
+	if len(callBz) == 0 {
+		return nil, fmt.Errorf("contract call is empty; an empty body is never a valid cellar instruction")
+	}
+
+	msg := &types.MsgScheduleCorkRequest{
+		Cork: &types.Cork{
+			EncodedContractCall:   callBz,
+			TargetContractAddress: contractAddr,
+		},
+		BlockHeight: blockHeight,
+		Signer:      signer,
+	}
+	if err := msg.ValidateBasic(); err != nil {
+		return nil, err
+	}
+	return msg, nil
+}
+
+func withHexPrefix(s string) string {
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		return s
+	}
+	return "0x" + s
+}
+
+// CmdScheduleCork schedules a cork against an Ethereum cellar.
+//
+// Only the cork_authority param may do this: v10 retires the
+// validator-delegate path that steward used, so this command is the supported
+// way to drive the cellar wind-down.
+func CmdScheduleCork() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "schedule-cork [target-contract-address] [block-height] [encoded-contract-call]",
+		Args:  cobra.ExactArgs(3),
+		Short: "Schedule a cork against an Ethereum cellar (cork authority only)",
+		Long: strings.TrimSpace(
+			fmt.Sprintf(`Schedule a cork to be submitted to Ethereum at a future block height.
+
+The signing account MUST be the cork_authority param; any other signer is
+rejected. The target contract must be on the managed-cellar allowlist, and the
+allowlist is re-checked at execution, so removing a cellar cancels calls already
+queued against it.
+
+The contract call is ABI-encoded bytes, given as hex (0x prefix optional).
+
+Example:
+$ %s tx cork schedule-cork 0x123801a7D398351b8bE11C439e05C5B3259aeC9B 27500000 0xa9059cbb... --from cork-authority
+`, version.AppName)),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientTxContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			blockHeight, err := strconv.ParseUint(args[1], 10, 64)
+			if err != nil {
+				return fmt.Errorf("block height %s is invalid: %w", args[1], err)
+			}
+
+			msg, err := buildScheduleCorkMsg(
+				clientCtx.GetFromAddress().String(), args[0], blockHeight, args[2])
+			if err != nil {
+				return err
+			}
+
+			return tx.GenerateOrBroadcastTxCLI(clientCtx, cmd.Flags(), msg)
+		},
+	}
+
+	flags.AddTxFlagsToCmd(cmd)
+	return cmd
 }
 
 // GetCmdSubmitAddProposal implements the command to submit a cellar id addition proposal

--- a/x/cork/client/cli/tx_test.go
+++ b/x/cork/client/cli/tx_test.go
@@ -2,14 +2,24 @@ package cli
 
 import (
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/peggyjv/sommelier/v10/app/params"
 	types "github.com/peggyjv/sommelier/v10/x/cork/types/v2"
 
 	"github.com/cosmos/cosmos-sdk/testutil"
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/stretchr/testify/require"
 )
+
+// The SDK config defaults to the "cosmos" bech32 prefix. The app calls
+// SetAddressPrefixes at init; this package does not, so without it every
+// somm1... address fails ValidateBasic with a misleading "expected cosmos".
+func TestMain(m *testing.M) {
+	params.SetAddressPrefixes()
+	os.Exit(m.Run())
+}
 
 func TestParseAddManagedCellarsProposal(t *testing.T) {
 	encodingConfig := moduletestutil.MakeTestEncodingConfig()
@@ -88,4 +98,61 @@ func TestParseSubmitScheduledCorkProposal(t *testing.T) {
 	require.Equal(t, "I have a hunch", proposal.Description)
 	require.Equal(t, "{\"cellar_id\":\"0x123801a7D398351b8bE11C439e05C5B3259aeC9B\",\"cellar_v1\":{\"some_fuction\":{\"function_args\":{}},\"block_height\":12345}}", proposal.ContractCallProtoJson)
 	require.Equal(t, "1000stake", proposal.Deposit)
+}
+
+// The cork authority needs a direct path to schedule a cork. Before v10 this
+// was steward's job via the validator-delegate path, which v10 retires: the
+// msg server now requires signer == params.CorkAuthority, so steward's corks
+// are rejected and there was no CLI able to send one.
+func TestGetTxCmdRegistersScheduleCork(t *testing.T) {
+	cmd := GetTxCmd()
+	var found bool
+	for _, c := range cmd.Commands() {
+		if strings.HasPrefix(c.Use, "schedule-cork") {
+			found = true
+		}
+	}
+	require.True(t, found,
+		"tx cork must expose schedule-cork; without it the cork authority has no way "+
+			"to schedule an Ethereum cork and the cellar wind-down cannot be driven")
+}
+
+func TestBuildScheduleCorkMsg(t *testing.T) {
+	const (
+		cellar = "0x123801a7D398351b8bE11C439e05C5B3259aeC9B"
+		signer = "somm1lcsjy2d5s33h0sddd8lpuqvwyz5ruz7ju4aeqa"
+	)
+
+	t.Run("hex call is decoded to bytes, not passed through as ASCII", func(t *testing.T) {
+		msg, err := buildScheduleCorkMsg(signer, cellar, 1000, "0xdeadbeef")
+		require.NoError(t, err)
+		// The chain expects raw ABI-encoded bytes. Passing []byte("0xdeadbeef")
+		// would hand the cellar the ASCII of the hex string and the call would
+		// revert on chain, with nothing locally to indicate why.
+		require.Equal(t, []byte{0xde, 0xad, 0xbe, 0xef}, msg.Cork.EncodedContractCall)
+		require.Equal(t, cellar, msg.Cork.TargetContractAddress)
+		require.Equal(t, uint64(1000), msg.BlockHeight)
+		require.Equal(t, signer, msg.Signer)
+	})
+
+	t.Run("0x prefix is optional", func(t *testing.T) {
+		msg, err := buildScheduleCorkMsg(signer, cellar, 1000, "deadbeef")
+		require.NoError(t, err)
+		require.Equal(t, []byte{0xde, 0xad, 0xbe, 0xef}, msg.Cork.EncodedContractCall)
+	})
+
+	t.Run("rejects a non-hex call", func(t *testing.T) {
+		_, err := buildScheduleCorkMsg(signer, cellar, 1000, "not-hex")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects an invalid cellar address", func(t *testing.T) {
+		_, err := buildScheduleCorkMsg(signer, "0xnothex", 1000, "0xdeadbeef")
+		require.Error(t, err)
+	})
+
+	t.Run("rejects an empty call", func(t *testing.T) {
+		_, err := buildScheduleCorkMsg(signer, cellar, 1000, "0x")
+		require.Error(t, err, "an empty call body is never a valid cellar instruction")
+	})
 }

--- a/x/poa/keeper/abci_test.go
+++ b/x/poa/keeper/abci_test.go
@@ -1,6 +1,7 @@
 package keeper_test
 
 import (
+	"cosmossdk.io/math"
 	"testing"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -21,7 +22,7 @@ func noopStakingEndBlocker(_ sdk.Context) []abci.ValidatorUpdate { return nil }
 // addValidatorWithPubkey is like fakeStakingKeeper.addValidator but also
 // attaches a deterministic ed25519 pubkey so mergeUpdatesWithBoost can
 // extract a TmConsPublicKey.
-func (f *fakeStakingKeeper) addValidatorWithPubkey(t *testing.T, op sdk.ValAddress, tokens sdk.Int) {
+func (f *fakeStakingKeeper) addValidatorWithPubkey(t *testing.T, op sdk.ValAddress, tokens math.Int) {
 	t.Helper()
 	v := f.addValidator(op, tokens)
 	pk := ed25519.GenPrivKeyFromSecret(op).PubKey()

--- a/x/poa/keeper/abci_test.go
+++ b/x/poa/keeper/abci_test.go
@@ -8,7 +8,6 @@ import (
 	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/peggyjv/sommelier/v10/x/poa/keeper"
@@ -22,7 +21,7 @@ func noopStakingEndBlocker(_ sdk.Context) []abci.ValidatorUpdate { return nil }
 // addValidatorWithPubkey is like fakeStakingKeeper.addValidator but also
 // attaches a deterministic ed25519 pubkey so mergeUpdatesWithBoost can
 // extract a TmConsPublicKey.
-func (f *fakeStakingKeeper) addValidatorWithPubkey(t *testing.T, op sdk.ValAddress, tokens sdk.Int) stakingtypes.Validator {
+func (f *fakeStakingKeeper) addValidatorWithPubkey(t *testing.T, op sdk.ValAddress, tokens sdk.Int) {
 	t.Helper()
 	v := f.addValidator(op, tokens)
 	pk := ed25519.GenPrivKeyFromSecret(op).PubKey()
@@ -30,7 +29,6 @@ func (f *fakeStakingKeeper) addValidatorWithPubkey(t *testing.T, op sdk.ValAddre
 	require.NoError(t, err)
 	v.ConsensusPubkey = any
 	f.validators[op.String()] = v
-	return v
 }
 
 // init ensures crypto codec is registered so AnyWithValue serialises pubkeys.

--- a/x/poa/types/params_test.go
+++ b/x/poa/types/params_test.go
@@ -23,6 +23,7 @@ func TestValidateFloor(t *testing.T) {
 		{"zero rejected", "0.0", false},
 	}
 	for _, tc := range cases {
+		tc := tc // capture per iteration; the subtests below close over it
 		t.Run(tc.name, func(t *testing.T) {
 			err := validateFloor(sdk.MustNewDecFromStr(tc.floor))
 			if tc.valid {


### PR DESCRIPTION
v10 replaces the validator-supermajority cork path with a single
`cork_authority` param. Both cork modules enforce it:

```go
if params.CorkAuthority == "" || signer.String() != params.CorkAuthority {
    return nil, ErrUnauthorized "signer %s is not the cork authority"
}
```

That is correct — but it left **no working client for scheduling a cork**, which
is the operation the release exists to enable. Found while preparing the v10
cellar wind-down.

## What was broken

**x/cork had no direct command at all.** `GetTxCmd()` registered no subcommands
(`// todo(mvid): figure out what is useful, implement`), and the only
`schedule-cork` was a *governance proposal* command — the mechanism v10 exists
to replace. `MsgScheduleCorkRequest` was constructed nowhere in `x/cork/client`.

**steward, which scheduled corks in production, is now rejected.** It sends
`signer: get_delegate_address()`, so every cork it submits fails with
`ErrUnauthorized` after the upgrade. It also cannot be repointed at the
authority: it loads its key from an on-disk FsKeyStore and so cannot sign for an
authority held on a hardware wallet, which is the deployed configuration.
(Companion change in steward makes that failure self-explanatory rather than
reporting "this may be a steward configuration problem".)

**`schedule-axelar-cork` never worked.** It built an `AxelarCork` without
`Deadline`, which `ValidateBasic` requires to be non-zero, so every invocation
failed before broadcasting. I had assumed this path was fine because its signer
handling looked right; it isn't, and it needed running to find that.

**Both commands mis-encoded the contract call.** `[]byte(args[3])`, under a
`todo: how are contract calls submitted?` comment, passes the ASCII of the hex
string instead of the ABI-encoded call. This is the nastiest of the four: the
Sommelier transaction *succeeds*, the call then reverts on the destination
chain, and nothing locally indicates why. In axelarcork the deadline defect
masked it.

## What this does

- Adds `tx cork schedule-cork [cellar] [block-height] [hex-call]`
- Adds a required `--deadline` flag to `schedule-axelar-cork` (unix timestamp
  enforced by the destination proxy contract)
- Decodes the contract call from hex in both, with `0x` optional
- Splits `buildScheduleCorkMsg` / `buildScheduleAxelarCorkMsg` out of the cobra
  commands so the encoding rules are testable without a client context

Tests cover hex decoding, both prefix forms, and rejection of non-hex calls,
empty calls, invalid addresses, and a zero deadline — plus that `--deadline` is
actually wired to the command, since an unwired flag silently reintroduces the
original defect.

Also adds `TestMain` calling `params.SetAddressPrefixes` in both CLI test
packages: the SDK config defaults to the `cosmos` prefix, so without it every
`somm1...` address fails `ValidateBasic` with a misleading "expected cosmos,
got somm".

## Verification

Unit suite 23 ok / 0 FAIL. Both commands confirmed present and correctly
documented in a built binary.

**Not yet exercised against a live chain.** These are unit-tested only; no
`schedule-cork` has been signed by a real authority key and executed end to end.
Worth doing on a rehearsal chain before driving real vault recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added commands for scheduling Cork and Axelar Cork transactions.
  - Added support for hexadecimal contract call data, including optional `0x` prefixes.
  - Added a required deadline option for scheduled Axelar Cork transactions.
  - Added validation for target addresses, call data, block heights, and deadlines.

- **Bug Fixes**
  - Invalid, empty, or malformed transaction inputs are now rejected before broadcasting.
  - Corrected formatting in a v10 upgrade error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->